### PR TITLE
add `babel-polyfill`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import { resolve } from 'path'
 import { all } from 'bluebird'
 import purify from 'purify-css'


### PR DESCRIPTION
This fixed some of the errors I was getting around #6.

I still had to hack Gatsby core to get it to ignore the invalid exports. I think you need to change the webpack / babel config to only export `sourceNodes` but I don't know how to do that, so no PR on that front.